### PR TITLE
add custom font size mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ const data = [
   { text: 'duck', value: 10 },
 ]
 
-<WordCloud data={data} />
+const fontSizeMapper = word => word.value * 2;
+
+<WordCloud data={data} fontSizeMapper={fontSizeMapper} />
 ```
 
 ## build

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "lint": "eslint .",
     "build": "NODE_ENV=production npm run build:dev",
     "build:dev": "babel src -d lib",
-    "test-only": "NODE_ENV=test mocha $npm_package_options_mocha",
+    "test-only": "jest",
     "test:watch": "npm run test-only -- --watch",
     "coverage": "nyc --check-coverage --lines 10 --functions 10 npm run test-only",
-    "test": "npm run lint && jest"
+    "test": "npm run lint && npm run test-only"
   },
   "repository": {
     "type": "git",

--- a/src/WordCloud.js
+++ b/src/WordCloud.js
@@ -5,11 +5,14 @@ import cloud from 'd3-cloud';
 
 const fill = d3.scaleOrdinal(d3.schemeCategory10);
 
+const defaultFontSizeMapper = word => word.value;
+
 class WordCloud extends Component {
   static defaultProps = {
     width: 700,
     height: 600,
     font: 'serif',
+    fontSizeMapper: defaultFontSizeMapper,
   }
 
   componentWillMount() {
@@ -17,25 +20,18 @@ class WordCloud extends Component {
   }
 
   render() {
-    const { data, width, height, font } = this.props;
+    const { data, width, height, font, fontSizeMapper } = this.props;
     const wordCounts = data.map(
       text => ({ ...text })
     );
-    const defaultFontSizeMapper = (word) => {
-      const max = 100;
-      const min = 10;
-      const wordCountSize = wordCounts.map(w => w.value);
-      const minSize = Math.min(...wordCountSize);
-      const maxSize = Math.max(...wordCountSize);
-      return min + (max - min) * (word.value - minSize) / (maxSize - minSize);
-    };
+
     const layout = cloud()
       .size([width, height])
       .font(font)
       .words(wordCounts)
       .padding(5)
       .rotate(() => 0)
-      .fontSize(defaultFontSizeMapper)
+      .fontSize(fontSizeMapper)
       .on('end', words => {
         d3.select(this.wordCloud)
           .append('svg')
@@ -71,6 +67,7 @@ WordCloud.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   font: PropTypes.string,
+  fontSizeMapper: PropTypes.func,
 };
 
 export default WordCloud;

--- a/src/__test__/WordCloud.spec.js
+++ b/src/__test__/WordCloud.spec.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import renderer from 'react-test-renderer';
 
@@ -20,5 +19,13 @@ describe('index.js', () => {
     ).toJSON();
     expect(component).toMatchSnapshot();
     Math.random = originalRandom;
+  });
+
+  it('should call custom fontSizeMapper', () => {
+    const fontSizeMapper = jest.fn().mockReturnValue(10);
+    renderer.create(
+      <WordCloud data={data} fontSizeMapper={fontSizeMapper} />
+    );
+    expect(fontSizeMapper.mock.calls.length).toBe(data.length);
   });
 });

--- a/src/__test__/__snapshots__/WordCloud.spec.js.snap
+++ b/src/__test__/__snapshots__/WordCloud.spec.js.snap
@@ -13,48 +13,36 @@ exports[`index.js should contain all words 1`] = `
           Object {
             "fill": "#1f77b4",
             "fontFamily": "Impact",
-            "fontSize": "100px",
+            "fontSize": "200px",
           }
         }
         textAnchor="middle"
         transform="translate(0,0)rotate(0)">
-        Hey
+        lol
       </text>
       <text
         style={
           Object {
             "fill": "#ff7f0e",
             "fontFamily": "Impact",
-            "fontSize": "27px",
+            "fontSize": "10px",
           }
         }
         textAnchor="middle"
-        transform="translate(-7,32)rotate(0)">
-        lol
+        transform="translate(-9,18)rotate(0)">
+        duck
       </text>
       <text
         style={
           Object {
             "fill": "#2ca02c",
             "fontFamily": "Impact",
-            "fontSize": "10px",
+            "fontSize": "1px",
           }
         }
         textAnchor="middle"
-        transform="translate(-47,18)rotate(0)">
+        transform="translate(5,-16)rotate(0)">
         cool
-      </text>
-      <text
-        style={
-          Object {
-            "fill": "#d62728",
-            "fontFamily": "Impact",
-            "fontSize": "10px",
-          }
-        }
-        textAnchor="middle"
-        transform="translate(-19,48)rotate(0)">
-        duck
       </text>
     </g>
   </svg>


### PR DESCRIPTION
```jsx
import WordCloud from 'react-d3-cloud'

const data = [
  { text: 'Hey', value: 1000 },
  { text: 'lol', value: 200 },
  { text: 'first impression', value: 800 },
  { text: 'cool', value: 1 },
  { text: 'duck', value: 10 },
]

const fontSizeMapper = word => word.value * 2;

<WordCloud data={data} fontSizeMapper={fontSizeMapper} />
```