### PR TITLE
V0.3.0 prebranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ for more detailed props, please refer to below:
 
 name | description | type | default
 -----|-------------|------|--------
-data|the input data for rendering|Array, each element should have shape: `{ text: String, value: NUmber}`|N/A, should be provided
-width|width of component |number|700
-height|height of component|number|600
-fontSizeMapper|map each element of `data` to font size|function: `(word, idx) => {return number}`|`word => word.value;`
-rotate|Map each element of `data` to font rotation degree. Or simply provide a number for global rotation.|function or number|0
-padding|Map each element of `data` to font padding. Or simply provide a number for global padding.|function or number|5
+data|the input data for rendering|Array, each element should have shape: `{ text: String, value: Number}`|N/A, should be provided
+width|width of component(px) |number|700
+height|height of component(px)|number|600
+fontSizeMapper|map each element of `data` to font size(px)|function: `(word, idx) => {return number}`|`word => word.value;`
+rotate|Map each element of `data` to font rotation degree. Or simply provide a number for global rotation.(degree)|function or number|0
+padding|Map each element of `data` to font padding. Or simply provide a number for global padding.(px)|function or number|5
 font|the font of text shown|function or string|serif
 
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,21 @@ render(
 );
 ```
 
-## example
-![image](https://cloud.githubusercontent.com/assets/6868283/20204452/ac873c54-a80a-11e6-8872-252efc0c15da.png)
-There will be a official gh-pages demo in the next 2 releases.
+for more detailed props, please refer to below:
+
+
+## Props
+
+name | description | type | default
+-----|-------------|------|--------
+data|the input data for rendering|Array, each element should have shape: `{ text: String, value: NUmber}`|N/A, should be provided
+width|width of component |number|700
+height|height of component|number|600
+fontSizeMapper|map each element of `data` to font size|function: `(word, idx) => {return number}`|`word => word.value;`
+rotate|Map each element of `data` to font rotation degree. Or simply provide a number for global rotation.|function or number|0
+padding|Map each element of `data` to font padding. Or simply provide a number for global padding.|function or number|5
+font|the font of text shown|function or string|serif
+
 
 ## build
 ```

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -11,8 +11,13 @@ const data = [
 ];
 
 const fontSizeMapper = word => Math.log2(word.value) * 5;
+const rotate = word => word.value % 360;
 
 render(
-  <WordCloud data={data} fontSizeMapper={fontSizeMapper} />,
+  <WordCloud
+    data={data}
+    fontSizeMapper={fontSizeMapper}
+    rotate={rotate}
+  />,
   document.getElementById('root')
 );

--- a/src/WordCloud.js
+++ b/src/WordCloud.js
@@ -5,7 +5,6 @@ import cloud from 'd3-cloud';
 
 import {
   defaultFontSizeMapper,
-  defaultRotate,
 } from './defaultMappers';
 
 
@@ -41,7 +40,7 @@ class WordCloud extends Component {
     padding: 5,
     font: 'serif',
     fontSizeMapper: defaultFontSizeMapper,
-    rotate: defaultRotate,
+    rotate: 0,
   }
 
   componentWillMount() {

--- a/src/WordCloud.js
+++ b/src/WordCloud.js
@@ -3,10 +3,14 @@ import ReactFauxDom from 'react-faux-dom';
 import * as d3 from 'd3';
 import cloud from 'd3-cloud';
 
+import {
+  defaultFontSizeMapper,
+  defaultRotate,
+} from './defaultMappers';
+
+
 const fill = d3.scaleOrdinal(d3.schemeCategory10);
 
-const defaultFontSizeMapper = word => word.value;
-const defaultRotate = word => (word.value % 180) - 90;
 
 class WordCloud extends Component {
   static propTypes = {

--- a/src/__tests__/__snapshots__/WordCloud.spec.js.snap
+++ b/src/__tests__/__snapshots__/WordCloud.spec.js.snap
@@ -17,7 +17,7 @@ exports[`index.js should contain all words 1`] = `
           }
         }
         textAnchor="middle"
-        transform="translate(0,0)rotate(-70)">
+        transform="translate(0,0)rotate(0)">
         lol
       </text>
       <text
@@ -29,7 +29,7 @@ exports[`index.js should contain all words 1`] = `
           }
         }
         textAnchor="middle"
-        transform="translate(20,21)rotate(-80)">
+        transform="translate(-9,18)rotate(0)">
         duck
       </text>
       <text
@@ -41,7 +41,7 @@ exports[`index.js should contain all words 1`] = `
           }
         }
         textAnchor="middle"
-        transform="translate(18,0)rotate(-89)">
+        transform="translate(5,-16)rotate(0)">
         cool
       </text>
     </g>

--- a/src/defaultMappers/defaultFontSizeMapper.js
+++ b/src/defaultMappers/defaultFontSizeMapper.js
@@ -1,0 +1,3 @@
+const defaultFontSizeMapper = word => word.value;
+
+export default defaultFontSizeMapper;

--- a/src/defaultMappers/defaultRotate.js
+++ b/src/defaultMappers/defaultRotate.js
@@ -1,3 +1,0 @@
-const defaultRotate = word => (word.value % 180) - 90;
-
-export default defaultRotate;

--- a/src/defaultMappers/defaultRotate.js
+++ b/src/defaultMappers/defaultRotate.js
@@ -1,0 +1,3 @@
+const defaultRotate = word => (word.value % 180) - 90;
+
+export default defaultRotate;

--- a/src/defaultMappers/index.js
+++ b/src/defaultMappers/index.js
@@ -1,2 +1,1 @@
 export defaultFontSizeMapper from './defaultFontSizeMapper';
-export defaultRotate from './defaultRotate';

--- a/src/defaultMappers/index.js
+++ b/src/defaultMappers/index.js
@@ -1,0 +1,2 @@
+export defaultFontSizeMapper from './defaultFontSizeMapper';
+export defaultRotate from './defaultRotate';


### PR DESCRIPTION
- change default rotate to 0
- update basic example
- a little refactoring
- In README.md, add a section to describe props:

## Props

name | description | type | default
-----|-------------|------|--------
data|the input data for rendering|Array, each element should have shape: `{ text: String, value: NUmber}`|N/A, should be provided
width|width of component |number|700
height|height of component|number|600
fontSizeMapper|map each element of `data` to font size|function: `(word, idx) => {return number}`|`word => word.value;`
rotate|Map each element of `data` to font rotation degree. Or simply provide a number for global rotation.|function or number|0
padding|Map each element of `data` to font padding. Or simply provide a number for global padding.|function or number|5
font|the font of text shown|function or string|serif