### PR TITLE
use module.exports to export root module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 import WordCloud from './WordCloud';
 
-export default WordCloud;
+module.exports = WordCloud;


### PR DESCRIPTION
so we can use

```js
require('react-d3-cloud')
```

instead of

```js
require('react-d3-cloud').default
```