### PR TITLE
add React.memo to avoid unnecessary re-render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13342,6 +13342,11 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-faux-dom": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/react-faux-dom/-/react-faux-dom-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "d3-scale-chromatic": "^2.0.0",
     "d3-selection": "^2.0.0",
     "prop-types": "^15.7.2",
+    "react-fast-compare": "^3.2.0",
     "react-faux-dom": "^4.5.0"
   },
   "peerDependencies": {

--- a/src/WordCloud.js
+++ b/src/WordCloud.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
+import React, { useRef } from 'react';
 import ReactFauxDom from 'react-faux-dom';
 import cloud from 'd3-cloud';
+import isDeepEqual from 'react-fast-compare';
 import { scaleOrdinal } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { select } from 'd3-selection';
-import { useRef } from 'react';
 
 // From: https://github.com/jasondavies/d3-cloud/blob/4fc1a943d01d270e7838c97bb8ee48ca15da20be/index.js#L355-L378
 function archimedeanSpiral(size) {
@@ -173,4 +174,4 @@ WordCloud.defaultProps = {
   onWordMouseOut: null,
 };
 
-export default WordCloud;
+export default React.memo(WordCloud, isDeepEqual);


### PR DESCRIPTION
#97

After these changes, we can wrap functions with `useCallback` to avoid  unnecessary re-render

```js
import React, { useCallback } from 'react';
import { render } from 'react-dom';
import WordCloud from 'react-d3-cloud';
import { scaleOrdinal } from 'd3-scale';
import { schemeCategory10 } from 'd3-scale-chromatic';

function App() {
  const data = [
    { text: 'Hey', value: 1000 },
    { text: 'lol', value: 200 },
    { text: 'first impression', value: 800 },
    { text: 'very cool', value: 1000000 },
    { text: 'duck', value: 10 },
  ];
  
  const fontSize = useCallback((word) => Math.log2(word.value) * 5, []);
  const rotate = useCallback((word) => word.value % 360, []);
  const fill = useCallback((d, i) => scaleOrdinal(schemeCategory10)(i), []);
  const onWordClick = useCallback((word) => {
    console.log(`onWordClick: ${word}`);
  }, []);
  const onWordMouseOver = useCallback((word) => {
    console.log(`onWordMouseOver: ${word}`);
  }, []);
  const onWordMouseOut = useCallback((word) => {
    console.log(`onWordMouseOut: ${word}`);
  }, []);

  return (
    <WordCloud
      data={data}
      width={500}
      height={500}
      font="Times"
      fontStyle="italic"
      fontWeight="bold"
      fontSize={fontSize}
      spiral="rectangular"
      rotate={rotate}
      padding={5}
      random={Math.random}
      fill={fill}
      onWordClick={onWordClick}
      onWordMouseOver={onWordMouseOver}
      onWordMouseOut={onWordMouseOut}
    />
  );
);
```